### PR TITLE
not handling correct encoding

### DIFF
--- a/lib/cep_facil.rb
+++ b/lib/cep_facil.rb
@@ -30,7 +30,16 @@ module CepFacil
   # Some applications store Brazilian zip codes (CEPs) in formats like "22222222", or "22222-222"
   # or even as an integer. This method accept these three possible formats so you don´t need to format it yourself.
   
-  def get_address(zip_code, token)
+  def get_address(zip_code, token, dictionary = {})
+    dictionary = {
+      "tipo" => :type,
+      "cidade" => :city,
+      "bairro" => :neighborhood,
+      "cep" => :cep,
+      "descricao" => :description,
+      "uf" => :state
+    }.merge(dictionary)
+
     zip_code = zip_code.to_s
     
     if zip_code.match(/^[0-9]{5}[-]?[0-9]{3}/)
@@ -43,14 +52,6 @@ module CepFacil
     http = Net::HTTP.new(@uri.host, @uri.port)
     call = Net::HTTP::Get.new(@uri.request_uri)
     
-    dictionary = {
-      "tipo" => :type,
-      "cidade" => :city,
-      "bairro" => :neighborhood,
-      "cep" => :cep,
-      "descricao" => :description,
-      "uf" => :state
-    }
     response = http.request(call)
     address = Hash[* CGI::parse(response.body).map {|key, value| [dictionary[key],value[0]]}.flatten]
   end

--- a/lib/cep_facil.rb
+++ b/lib/cep_facil.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+require "cgi"
 require "cep_facil/version"
 require "net/http"
 
@@ -42,27 +43,16 @@ module CepFacil
     http = Net::HTTP.new(@uri.host, @uri.port)
     call = Net::HTTP::Get.new(@uri.request_uri)
     
-    response = http.request(call)
-    response.body
-    
-    pattern = /^([a-z]+)\=/
-    result = response.body.split("&")
-    
-    type = result[2].gsub!(pattern, "")
-    state = result[3].gsub!(pattern, "")
-    city = result[4].gsub!(pattern, "")
-    neighborhood = result[5].gsub!(pattern, "")
-    description = result[6].gsub!(pattern, "")
-    
-    address = {
-      cep: zip_code,
-      type: type,
-      state: state,
-      city: city,
-      neighborhood: neighborhood,
-      description: description
+    dictionary = {
+      "tipo" => :type,
+      "cidade" => :city,
+      "bairro" => :neighborhood,
+      "cep" => :cep,
+      "descricao" => :description,
+      "uf" => :state
     }
-  
+    response = http.request(call)
+    address = Hash[* CGI::parse(response.body).map {|key, value| [dictionary[key],value[0]]}.flatten]
   end
   
   # Receives and address hash and returns its extense version

--- a/lib/cep_facil/version.rb
+++ b/lib/cep_facil/version.rb
@@ -1,3 +1,3 @@
 module CepFacil
-  VERSION = "0.1.1" #:nodoc:
+  VERSION = "0.1.2" #:nodoc:
 end

--- a/spec/cep_facil_spec.rb
+++ b/spec/cep_facil_spec.rb
@@ -73,6 +73,21 @@ describe CepFacil do
     address[:description].should eql("Coronel Camisão")
   end
 
+  it "support a different dictionary" do
+    cep = "79005-340"
+    dictionary = {
+      "tipo" => :type,
+      "cidade" => :city,
+      "bairro" => :district,
+      "cep" => :zipcode,
+      "descricao" => :street,
+      "uf" => :uf
+    }
+    address = CepFacil.get_address cep, @token, dictionary
+    address[:zipcode].should eql("79005340")
+    address[:uf].should eql("MS")
+    address[:district].should eql("Amambaí")
+  end
 =begin  
   it "has a working alternative usage" do
     include CepFacil

--- a/spec/cep_facil_spec.rb
+++ b/spec/cep_facil_spec.rb
@@ -66,6 +66,13 @@ describe CepFacil do
     full_version.should eql("Rua Panelas, Artur Lundgren II, Paulista-PE, Brasil.")
   end
 
+  it "handles correct encoding" do
+    cep = "79005-340"
+    address = CepFacil.get_address cep, @token
+    address[:neighborhood].should eql("Amambaí")
+    address[:description].should eql("Coronel Camisão")
+  end
+
 =begin  
   it "has a working alternative usage" do
     include CepFacil


### PR DESCRIPTION
fixing this bug:
{:cep=>"79005340", :type=>"Rua", :state=>"MS", :city=>"Campo Grande", :neighborhood=>"Amamba\xC3\xAD", :description=>"Coronel Camis\xC3\xA3o"}
